### PR TITLE
Correct some printing errors

### DIFF
--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -194,7 +194,7 @@
 			<p>Devanne understood, and conducted the Englishman to the salon. In a dry, crisp voice, in sentences that seemed to have been prepared in advance, Holmes asked a number of questions about the events of the preceding evening, and enquired also concerning the guests and the members of the household. Then he examined the two volumes of the <i epub:type="se:name.publication.book">Chronique</i>, compared the plans of the subterranean passage, requested a repetition of the sentences discovered by Father Gélis, and then asked:</p>
 			<p>“Was yesterday the first time you have spoken of those two sentences to anyone?”</p>
 			<p>“Yes.”</p>
-			<p>“You had never communicated then to Horace Velmont?”</p>
+			<p>“You had never communicated them to Horace Velmont?”</p>
 			<p>“No.”</p>
 			<p>“Well, order the automobile. I must leave in an hour.”</p>
 			<p>“In an hour?”</p>

--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -270,6 +270,7 @@
 			<p>“Ah! there’s an auto waiting for us.”</p>
 			<p>“Yes, it is mine,” said Devanne.</p>
 			<p>“Yours? You said your chauffeur hadn’t returned.”</p>
+			<p>“That is right. I wonder how it came⁠—”</p>
 			<p>They approached the machine, and <abbr>Mon.</abbr> Devanne questioned the chauffer:</p>
 			<p>“Édouard, who gave you orders to come here?”</p>
 			<p>“Why, it was Monsieur Velmont.”</p>
@@ -284,7 +285,6 @@
 			<p>“Have you seen him?”</p>
 			<p>“I met him a short time ago⁠—on my way from the station.”</p>
 			<p>“And you knew it was Horace Velmont⁠—I mean, Arsène Lupin?”</p>
-			<p>“That is right. I wonder how it came⁠—”</p>
 			<p>“No, but I supposed it was⁠—from a certain ironical speech he made.”</p>
 			<p>“And you allowed him to escape?”</p>
 			<p>“Of course I did. And yet I had everything on my side, such as five gendarmes who passed us.”</p>


### PR DESCRIPTION
These two commits take care of the two issues that we've [discussed on the mailing list](https://groups.google.com/forum/#!topic/standardebooks/8IaDNUTiv8E):

- An apparent typo where "then" was used instead of "them".
- A line of dialog that was moved out of place between the French and English printings.